### PR TITLE
Bump ruby version dependency

### DIFF
--- a/flex-station-data.gemspec
+++ b/flex-station-data.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.3"
+  spec.required_ruby_version = ">= 2.4.4"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/flex_station_data/version.rb
+++ b/lib/flex_station_data/version.rb
@@ -1,3 +1,3 @@
 module FlexStationData
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
A gem dependency (`zeitwerk`) requires version 2.4.4 of Ruby, so bump our Ruby version dependency to match.